### PR TITLE
fix: allow plugin reload by clearing commands after registration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,12 @@ jobs:
         run: ./gradlew clean dokkaGenerateHtml --no-configuration-cache --rerun-tasks
 
       - name: Verify docs exist
-        run: ls -la build/docs/
+        run: ls -la build/dokka/html/
 
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: build/docs
+          path: build/dokka/html
 
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-See [AGENTS.md](AGENTS.md).

--- a/src/main/kotlin/de/jarox/paplin/PaplinPlugin.kt
+++ b/src/main/kotlin/de/jarox/paplin/PaplinPlugin.kt
@@ -33,12 +33,10 @@ abstract class PaplinPlugin : JavaPlugin() {
 
     /**
      * Initializes the PluginInstance and calls the load method.
-     * @throws IllegalStateException if PluginInstance is already initialized.
+     * Supports plugin reloads by allowing reassignment.
      */
     final override fun onLoad() {
-        if (::pluginInstance.isInitialized) {
-            throw IllegalStateException("PluginInstance is already initialized.")
-        }
+        // Allow reassignment to support plugin reloads
         pluginInstance = this
         load()
     }

--- a/src/main/kotlin/de/jarox/paplin/command/BrigadierSupport.kt
+++ b/src/main/kotlin/de/jarox/paplin/command/BrigadierSupport.kt
@@ -47,6 +47,7 @@ object BrigadierSupport {
         for (command in commands) {
             resolveCommandManager().dispatcher.register(command)
         }
+        commands.clear()
         if (onlinePlayers.isNotEmpty()) updateCommandTree()
     }
 


### PR DESCRIPTION
Removes the IllegalStateException on pluginInstance re-assignment and clears the Brigadier command buffer after registration to prevent double-registration on /reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin reloading is now supported without initialization restrictions.

* **Bug Fixes**
  * Fixed command registration to prevent duplicates on subsequent calls.
  * Corrected documentation deployment path for GitHub Pages.

* **Chores**
  * Updated release workflow with verification step before publishing documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/paplin/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->