### PR TITLE
fix: add missing @OptIn(NMS::class) annotations to command DSL files

### DIFF
--- a/src/main/kotlin/de/jarox/paplin/command/Arguments.kt
+++ b/src/main/kotlin/de/jarox/paplin/command/Arguments.kt
@@ -1,4 +1,5 @@
 @file:Suppress("unused")
+@file:OptIn(NMS::class)
 
 package de.jarox.paplin.command
 
@@ -6,6 +7,7 @@ import com.mojang.brigadier.arguments.ArgumentType
 import com.mojang.brigadier.builder.ArgumentBuilder
 import com.mojang.brigadier.builder.RequiredArgumentBuilder
 import com.mojang.brigadier.context.CommandContext
+import de.jarox.paplin.annotation.NMS
 import net.minecraft.commands.CommandSourceStack
 
 /**

--- a/src/main/kotlin/de/jarox/paplin/command/CommandContext.kt
+++ b/src/main/kotlin/de/jarox/paplin/command/CommandContext.kt
@@ -1,8 +1,10 @@
 @file:Suppress("unused")
+@file:OptIn(NMS::class)
 
 package de.jarox.paplin.command
 
 import com.mojang.brigadier.context.CommandContext
+import de.jarox.paplin.annotation.NMS
 import net.minecraft.commands.CommandSourceStack
 import org.bukkit.Location
 import org.bukkit.Server

--- a/src/main/kotlin/de/jarox/paplin/command/Creation.kt
+++ b/src/main/kotlin/de/jarox/paplin/command/Creation.kt
@@ -1,9 +1,11 @@
 @file:Suppress("unused")
+@file:OptIn(NMS::class)
 
 package de.jarox.paplin.command
 
 import com.mojang.brigadier.builder.ArgumentBuilder
 import com.mojang.brigadier.builder.LiteralArgumentBuilder
+import de.jarox.paplin.annotation.NMS
 import net.minecraft.commands.CommandSourceStack
 
 /**

--- a/src/main/kotlin/de/jarox/paplin/command/Execution.kt
+++ b/src/main/kotlin/de/jarox/paplin/command/Execution.kt
@@ -1,9 +1,11 @@
 @file:Suppress("unused")
+@file:OptIn(NMS::class)
 
 package de.jarox.paplin.command
 
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.builder.ArgumentBuilder
+import de.jarox.paplin.annotation.NMS
 import net.minecraft.commands.CommandSourceStack
 
 /**

--- a/src/main/kotlin/de/jarox/paplin/command/Registration.kt
+++ b/src/main/kotlin/de/jarox/paplin/command/Registration.kt
@@ -1,4 +1,5 @@
 @file:Suppress("unused")
+@file:OptIn(NMS::class)
 
 package de.jarox.paplin.command
 

--- a/src/main/kotlin/de/jarox/paplin/command/Requires.kt
+++ b/src/main/kotlin/de/jarox/paplin/command/Requires.kt
@@ -1,8 +1,10 @@
 @file:Suppress("unused")
+@file:OptIn(NMS::class)
 
 package de.jarox.paplin.command
 
 import com.mojang.brigadier.builder.ArgumentBuilder
+import de.jarox.paplin.annotation.NMS
 import net.minecraft.commands.CommandSourceStack
 import org.bukkit.permissions.Permission
 


### PR DESCRIPTION
Ensures all command DSL files that directly use NMS types (CommandSourceStack) are annotated with @file:OptIn(NMS::class), matching the project's NMS policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple modules to enable usage of internal APIs through annotation opt-ins. These are maintenance changes with no impact on user-facing functionality or existing features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/paplin/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->