### PR TITLE
fix: pin paper dev bundle build for reproducible builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    paperweight.paperDevBundle("$minecraftVersion.build.+")
+    paperweight.paperDevBundle(libs.versions.paper.get())
 }
 
 java {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 kotlin = "2.3.21"
 ktlint-plugin = "14.2.0"
 minecraft = "26.1.2"
+paper = "26.1.2.build.64-stable"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
Replaces the paperDevBundle wildcard with a pinned build number from the version catalog, ensuring reproducible builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated Paper server dependency to version 26.1.2.build.64-stable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/paplin/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->