### PR TITLE
feat: migrate to github packages and improve dev workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,12 +88,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify artifact on GitHub Packages
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.full }}"
           URL="https://maven.pkg.github.com/JaroxCraft/paplin/de/jarox/paplin/${VERSION}/paplin-${VERSION}.pom"
           echo "Polling: $URL"
           for i in $(seq 1 12); do
-            STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" "$URL")
+            STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" -u "$GITHUB_ACTOR:$GITHUB_TOKEN" "$URL")
             if [ "$STATUS" = "200" ]; then
               echo "Artifact confirmed after ${i} attempt(s)."
               exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,16 +84,16 @@ jobs:
       - name: Publish
         run: ./gradlew publish
         env:
-          REPSY_USER: ${{ secrets.REPSY_USER }}
-          REPSY_PASSWORD: ${{ secrets.REPSY_PASSWORD }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify artifact on Repsy
+      - name: Verify artifact on GitHub Packages
         run: |
           VERSION="${{ steps.version.outputs.full }}"
-          URL="https://repo.repsy.io/mvn/jaroxcraft/paplin/de/jarox/paplin/${VERSION}/paplin-${VERSION}.pom"
+          URL="https://maven.pkg.github.com/JaroxCraft/paplin/de/jarox/paplin/${VERSION}/paplin-${VERSION}.pom"
           echo "Polling: $URL"
           for i in $(seq 1 12); do
-            STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" "$URL")
+            STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" "$URL")
             if [ "$STATUS" = "200" ]; then
               echo "Artifact confirmed after ${i} attempt(s)."
               exit 0
@@ -101,7 +101,7 @@ jobs:
             echo "Attempt $i: HTTP $STATUS — waiting 5s"
             sleep 5
           done
-          echo "::error::Artifact not found on Repsy after 60 seconds."
+          echo "::error::Artifact not found on GitHub Packages after 60 seconds."
           exit 1
 
       - name: Create GitHub Release
@@ -113,7 +113,7 @@ jobs:
           prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
           body: |
             **Artifact:** `de.jarox:paplin:${{ steps.version.outputs.full }}`
-            **Repository:** `https://repo.repsy.io/mvn/jaroxcraft/paplin`
+            **Repository:** `https://maven.pkg.github.com/JaroxCraft/paplin`
 
             ```kotlin
             // gradle/libs.versions.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,14 @@
 
 ## What this is
 
-Kotlin library wrapping Paper Minecraft server API with idiomatic Kotlin DSLs. Published to Repsy Maven. No application entrypoint — consumed by downstream plugin projects. No test suite.
+Kotlin library wrapping Paper Minecraft server API with idiomatic Kotlin DSLs. Published to GitHub Packages. No application entrypoint — consumed by downstream plugin projects. No test suite.
 
 ## Critical facts
 
 - **Java target: 25** (not 21 — CLAUDE.md is stale)
 - **Version format:** `$paplinVersion+$minecraftVersion` (uses `+`, SemVer build metadata). The `+` separator is intentional — Maven resolves it fine on Repsy.
 - **Default branch is `master`**. CI workflows are configured for `master`.
-- **Repsy is public for reads** — no auth needed to fetch artifacts.
+- **GitHub Packages requires authentication for reads** — set `GITHUB_ACTOR` and `GITHUB_TOKEN` env vars.
 
 ## Commands
 
@@ -18,14 +18,14 @@ Kotlin library wrapping Paper Minecraft server API with idiomatic Kotlin DSLs. P
 ./gradlew ktlintFormat   # auto-format
 ./gradlew ktlintCheck    # check-only
 ./gradlew build          # compile only
-./gradlew publish        # requires REPSY_USER + REPSY_PASSWORD env vars
+./gradlew publish        # requires GITHUB_ACTOR + GITHUB_TOKEN env vars
 ```
 
 ## Releases
 
-Tag-driven. Push a `v*` tag → `release.yml` validates tag matches versions in `gradle.properties` and `gradle/libs.versions.toml`, publishes, polls Repsy for 60s, creates GitHub Release.
+Tag-driven. Push a `v*` tag → `release.yml` validates tag matches versions in `gradle.properties` and `gradle/libs.versions.toml`, publishes, polls GitHub Packages for 60s, creates GitHub Release.
 
-**Never hardcode credentials.** They come from `REPSY_USER` / `REPSY_PASSWORD` env vars.
+**Never hardcode credentials.** They come from `GITHUB_ACTOR` / `GITHUB_TOKEN` env vars.
 
 **The `+` character is NOT valid in GitHub Actions tag filter patterns.** Use `v*` and validate format in the script.
 
@@ -58,9 +58,12 @@ Pre-release tags (e.g. `v1.0.0-beta.1+26.1.2`) create GitHub Releases marked as 
 
 No in-library tests. To verify changes against a real plugin:
 
-1. `./gradlew publishToMavenLocal` (publishes to `~/.m2`)
-2. Add `mavenLocal()` before the Repsy repo in the example project's `build.gradle.kts`
-3. Build example project, remove `mavenLocal()` before committing
+1. **Composite build** (fastest, no publish needed):  
+   In the example project, run `./gradlew -Ppaplin.local.path=../paplin runServer`.
+
+2. **Maven local**:  
+   In Paplin, run `./gradlew publishToMavenLocal`.  
+   In the example project, run `./gradlew -PuseMavenLocal runServer`.
 
 ## `@NMS` policy
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Add Paplin as a dependency in your `build.gradle.kts`:
 repositories {
     maven {
         name = "Paplin"
-        url = uri("https://repo.repsy.io/mvn/jaroxcraft/paplin")
+        url = uri("https://maven.pkg.github.com/JaroxCraft/paplin")
+        credentials {
+            username = providers.environmentVariable("GITHUB_ACTOR").orNull
+            password = providers.environmentVariable("GITHUB_TOKEN").orNull
+        }
     }
-}
-
-dependencies {
-    implementation("de.jarox:paplin:<latest release>")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,14 +34,12 @@ publishing {
 
     repositories {
         maven {
-            name = "repsy"
-            url = uri("https://repo.repsy.io/mvn/jaroxcraft/paplin")
-
-            val credentials = System.getenv("REPSY_USER") to System.getenv("REPSY_PASSWORD")
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/JaroxCraft/paplin")
 
             credentials {
-                username = credentials.first
-                password = credentials.second
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
             }
         }
     }


### PR DESCRIPTION
Migrates Maven publication from Repsy to GitHub Packages. Also updates AGENTS.md and README with new auth env vars and improved downstream testing workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched publishing and artifact distribution to GitHub Packages and updated CI release workflow to authenticate using GITHUB_ACTOR/GITHUB_TOKEN.

* **Documentation**
  * Updated installation and publishing guidance to use GitHub Packages, added publish command instructions requiring those env vars, clarified artifact availability polling and release/tag handling (avoid + in tag filters), and revised downstream testing tips.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/paplin/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->