### PR TITLE
fix: include dokka html jar in maven publication

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,14 @@ java {
     withSourcesJar()
 }
 
+tasks.register<Jar>("dokkaHtmlJar") {
+    group = "documentation"
+    description = "Assembles a JAR archive containing the Dokka HTML documentation."
+    dependsOn(tasks.dokkaGenerateHtml)
+    from(tasks.dokkaGenerateHtml.map { it.outputs.files })
+    archiveClassifier.set("javadoc")
+}
+
 publishing {
 
     repositories {
@@ -49,6 +57,7 @@ publishing {
     publications {
         register<MavenPublication>(project.name) {
             from(components["java"])
+            artifact(tasks["dokkaHtmlJar"])
 
             pom {
                 this.url.set(ghRepoUrl)


### PR DESCRIPTION
Adds a Dokka HTML JAR artifact to the Maven publication so downstream IDEs can display inline documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package distribution to include official API documentation, making it readily available when obtaining the library from Maven repositories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/paplin/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->