### PR TITLE
refactor!: remove global pluginInstance, make APIs stateless

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Source: `src/main/kotlin/de/jarox/paplin/`
 
 - **Plugin lifecycle:** `PaplinPlugin.kt` — abstract base extending `JavaPlugin`
 - **Command DSL:** `command/` — Brigadier wrapper (`command { }`, `argument<T>()`, `runs { }`)
-- **Event DSL:** `event/Listeners.kt` — `listen<EventType> { }`
+- **Event DSL:** `event/Listeners.kt` — `listen<EventType>(plugin) { }`, `listener.register(plugin)`
 - **Chat:** `chat/ComponentBuilder.kt` — Kyori Adventure fluent builder
 - **Extensions:** `extension/` — `server`, `onlinePlayers`, `broadcast()`
 - **NMS annotation:** `annotation/NMS.kt` — opt-in for version-fragile APIs

--- a/src/main/kotlin/de/jarox/paplin/PaplinPlugin.kt
+++ b/src/main/kotlin/de/jarox/paplin/PaplinPlugin.kt
@@ -1,18 +1,8 @@
-@file:Suppress("EmptyMethod")
-
 package de.jarox.paplin
 
 import dev.jorel.commandapi.CommandAPI
 import dev.jorel.commandapi.CommandAPIPaperConfig
 import org.bukkit.plugin.java.JavaPlugin
-
-/**
- * Global reference to the currently loaded PaplinPlugin instance.
- *
- * @throws IllegalStateException if accessed before the plugin is loaded
- */
-lateinit var pluginInstance: PaplinPlugin
-    private set
 
 abstract class PaplinPlugin : JavaPlugin() {
     /**
@@ -35,12 +25,9 @@ abstract class PaplinPlugin : JavaPlugin() {
     open fun disable() {}
 
     /**
-     * Initializes the PluginInstance and the CommandAPI, then calls the load method.
-     * Supports plugin reloads by allowing reassignment.
+     * Initializes the CommandAPI, then calls the load method.
      */
     final override fun onLoad() {
-        // Allow reassignment to support plugin reloads
-        pluginInstance = this
         CommandAPI.onLoad(CommandAPIPaperConfig(this))
         load()
     }

--- a/src/main/kotlin/de/jarox/paplin/PaplinPlugin.kt
+++ b/src/main/kotlin/de/jarox/paplin/PaplinPlugin.kt
@@ -4,6 +4,7 @@ import dev.jorel.commandapi.CommandAPI
 import dev.jorel.commandapi.CommandAPIPaperConfig
 import org.bukkit.plugin.java.JavaPlugin
 
+@Suppress("unused")
 abstract class PaplinPlugin : JavaPlugin() {
     /**
      * Method to be overridden for custom load logic.

--- a/src/main/kotlin/de/jarox/paplin/event/Listeners.kt
+++ b/src/main/kotlin/de/jarox/paplin/event/Listeners.kt
@@ -2,11 +2,11 @@
 
 package de.jarox.paplin.event
 
-import de.jarox.paplin.pluginInstance
 import org.bukkit.event.Event
 import org.bukkit.event.EventPriority
 import org.bukkit.event.HandlerList
 import org.bukkit.event.Listener
+import org.bukkit.plugin.Plugin
 
 /**
  * Unregisters this listener from all events.
@@ -17,21 +17,23 @@ fun Listener.unregister() = HandlerList.unregisterAll(this)
  * Registers an event listener for the specified event type.
  *
  * @param T the type of the event
+ * @param plugin the plugin registering the listener
  * @param priority the priority of the event listener
  * @param ignoreCancelled whether to ignore canceled events
  * @param executor the function to execute when the event is triggered
  */
 inline fun <reified T : Event> Listener.register(
+    plugin: Plugin,
     priority: EventPriority = EventPriority.NORMAL,
     ignoreCancelled: Boolean = false,
     noinline executor: (Listener, Event) -> Unit,
 ) {
-    pluginInstance.server.pluginManager.registerEvent(
+    plugin.server.pluginManager.registerEvent(
         T::class.java,
         this,
         priority,
         executor,
-        pluginInstance,
+        plugin,
         ignoreCancelled,
     )
 }
@@ -59,14 +61,15 @@ abstract class SimpleListener<T : Event>(
  * Registers this listener.
  *
  * @param T the type of the event
+ * @param plugin the plugin registering the listener
  */
-inline fun <reified T : Event> SimpleListener<T>.register() {
-    pluginInstance.server.pluginManager.registerEvent(
+inline fun <reified T : Event> SimpleListener<T>.register(plugin: Plugin) {
+    plugin.server.pluginManager.registerEvent(
         T::class.java,
         this,
         priority,
         { _, event -> (event as? T)?.let { onEvent(it) } },
-        pluginInstance,
+        plugin,
         ignoreCancelled,
     )
 }
@@ -75,6 +78,7 @@ inline fun <reified T : Event> SimpleListener<T>.register() {
  * Creates and optionally registers a simple event listener.
  *
  * @param T the type of the event
+ * @param plugin the plugin registering the listener
  * @param priority the priority of the event listener
  * @param ignoreCancelled whether to ignore canceled events
  * @param register whether to register the listener automatically
@@ -82,6 +86,7 @@ inline fun <reified T : Event> SimpleListener<T>.register() {
  * @return the created simple event listener
  */
 inline fun <reified T : Event> listen(
+    plugin: Plugin,
     priority: EventPriority = EventPriority.NORMAL,
     ignoreCancelled: Boolean = false,
     register: Boolean = true,
@@ -91,6 +96,6 @@ inline fun <reified T : Event> listen(
         object : SimpleListener<T>(priority, ignoreCancelled) {
             override fun onEvent(event: T) = onEvent(event)
         }
-    if (register) listener.register()
+    if (register) listener.register(plugin)
     return listener
 }

--- a/src/main/kotlin/de/jarox/paplin/scheduler/Scheduler.kt
+++ b/src/main/kotlin/de/jarox/paplin/scheduler/Scheduler.kt
@@ -2,7 +2,7 @@
 
 package de.jarox.paplin.scheduler
 
-import de.jarox.paplin.PaplinPlugin
+import org.bukkit.plugin.Plugin
 import org.bukkit.scheduler.BukkitTask
 
 /**
@@ -12,7 +12,7 @@ import org.bukkit.scheduler.BukkitTask
  * @param block the code to execute on the main thread
  * @return the scheduled [BukkitTask] for cancellation or inspection
  */
-fun PaplinPlugin.runSync(
+fun Plugin.runSync(
     ticks: Long = 0,
     block: () -> Unit,
 ): BukkitTask = server.scheduler.runTaskLater(this, block, ticks)
@@ -23,7 +23,7 @@ fun PaplinPlugin.runSync(
  * @param block the code to execute asynchronously
  * @return the scheduled [BukkitTask] for cancellation or inspection
  */
-fun PaplinPlugin.runAsync(block: () -> Unit): BukkitTask = server.scheduler.runTaskAsynchronously(this, block)
+fun Plugin.runAsync(block: () -> Unit): BukkitTask = server.scheduler.runTaskAsynchronously(this, block)
 
 /**
  * Runs a repeating task synchronously on the main server thread.
@@ -33,7 +33,7 @@ fun PaplinPlugin.runAsync(block: () -> Unit): BukkitTask = server.scheduler.runT
  * @param block the code to execute repeatedly on the main thread
  * @return the scheduled [BukkitTask] for cancellation or inspection
  */
-fun PaplinPlugin.runTimer(
+fun Plugin.runTimer(
     interval: Long,
     delay: Long = 0,
     block: () -> Unit,
@@ -47,7 +47,7 @@ fun PaplinPlugin.runTimer(
  * @param block the code to execute repeatedly off the main thread
  * @return the scheduled [BukkitTask] for cancellation or inspection
  */
-fun PaplinPlugin.runAsyncTimer(
+fun Plugin.runAsyncTimer(
     interval: Long,
     delay: Long = 0,
     block: () -> Unit,


### PR DESCRIPTION
## Summary

Eliminates the global mutable `pluginInstance` singleton and converts all stateful APIs to explicitly accept a `Plugin` context.

## Breaking Changes

| API | Before | After |
|---|---|---|
| `listen<T>()` | `listen { }` | `listen(plugin) { }` |
| `Listener.register()` | `listener.register { }` | `listener.register(plugin) { }` |
| `SimpleListener.register()` | `listener.register()` | `listener.register(plugin)` |
| Scheduler extensions | `plugin.runSync { }` | `plugin.runSync { }` (now on `Plugin`, not just `PaplinPlugin`) |

## Rationale

- Fixes ClassLoader leaks during `/reload`
- Prevents race conditions when multiple plugins use Paplin
- Ensures correct plugin context for scheduled tasks and event listeners

## Checklist

- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew build` passes
- [x] No `pluginInstance` references remain in `src/`
- [x] `AGENTS.md` updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Event DSL docs to show the new listener registration pattern using an explicit plugin parameter.

* **Refactor**
  * Listener registration now requires an explicit plugin reference rather than relying on an implicit global.
  * Scheduling helpers were generalized to accept any standard plugin type.
  * Removed the global plugin instance to reduce coupling and improve clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/paplin/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->